### PR TITLE
Fixes JSON Accept Header as default

### DIFF
--- a/src/wiener_netze_smart_meter_api/client.py
+++ b/src/wiener_netze_smart_meter_api/client.py
@@ -176,6 +176,7 @@ class WNAPIClient:
                 return None
 
             headers = {
+                "Accept": "application/json",
                 "Authorization": f"Bearer {token}",
                 "x-Gateway-APIKey": self.api_key,
             }


### PR DESCRIPTION
WN SM API seems to default now to tabular response breaking the JSON response handling.
Setting explicit `"Accept": "application/json",` in header fixes the issue.